### PR TITLE
Don't raise errors for remote asset paths

### DIFF
--- a/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
+++ b/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
@@ -31,6 +31,7 @@ module Sprockets
       end
 
       def ensure_asset_will_be_precompiled!(source, ext)
+        return if asset_paths.is_uri? source
         asset_file = asset_paths.rewrite_extension(source, nil, ext)
         unless asset_environment.send(:matches_filter, Rails.application.config.assets.precompile, asset_file)
           raise AssetPaths::AssetNotPrecompiledError.new("#{asset_file} must be added to config.assets.precompile, " <<


### PR DESCRIPTION
This allows things like

```
= javascript_include_tag "https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"
```

which needn't be in the precompile array.
