### PR TITLE
Ensure that asset path is a string

### DIFF
--- a/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
+++ b/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
@@ -31,6 +31,7 @@ module Sprockets
       end
 
       def ensure_asset_will_be_precompiled!(source, ext)
+        source = source.to_s
         return if asset_paths.is_uri?(source)
         asset_file = asset_environment.resolve(asset_paths.rewrite_extension(source, nil, ext))
         unless asset_environment.send(:logical_path_for_filename, asset_file, Rails.application.config.assets.precompile)


### PR DESCRIPTION
I ran into problems when asset paths are given as symbols. This fixes that.
