### PR TITLE
Allow exceptions to the precompile enforcement

### DIFF
--- a/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
+++ b/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
@@ -30,10 +30,16 @@ module Sprockets
         Rails.application.config.assets.enforce_precompile
       end
 
+      def asset_list
+        ignored = Rails.application.config.assets.ignore_for_precompile || []
+        precompile = Rails.application.config.assets.precompile || []
+        precompile + ignored
+      end
+
       def ensure_asset_will_be_precompiled!(source, ext)
         return if asset_paths.is_uri?(source)
         asset_file = asset_environment.resolve(asset_paths.rewrite_extension(source, nil, ext))
-        unless asset_environment.send(:logical_path_for_filename, asset_file, Rails.application.config.assets.precompile)
+        unless asset_environment.send(:logical_path_for_filename, asset_file, asset_list)
           raise AssetPaths::AssetNotPrecompiledError.new("#{asset_file} must be added to config.assets.precompile, " <<
                                                          "otherwise it won't be precompiled for production!")
         end


### PR DESCRIPTION
I'm trying to use this gem in combination with brentd/xray-rails, a development-only gem which provides its own JS and CSS assets. These shouldn't be in the precompile array because that gem isn't used in production, but this gem gets angry that they're not. I need a way to "whitelist" certain items that aren't in the precompile array.
