### PR TITLE
Remove hard exclusion on Konacha and factor it out into a predicate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ You also need to add the following line to `config/environments/development.rb`:
     # Forces included assets to be added to config.assets.precompile
     config.assets.enforce_precompile = true
 
+You can also specify a predicate to be tested when the check is about to be enforced:
+
+    # Forces included assets to be added to config.assets.precompile
+    config.assets.enforce_precompile = ->{ !Konacha || Konacha.config.blank? }
+
 
 You will need to restart your Rails server whenever you make any changes to `config.assets.precompile`.
 

--- a/lib/assets_precompile_enforcer.rb
+++ b/lib/assets_precompile_enforcer.rb
@@ -1,6 +1,2 @@
 require "assets_precompile_enforcer/version"
-
-# Needs to be disabled for Konacha
-unless defined?(Konacha)
-  require "assets_precompile_enforcer/sprockets/helpers/rails_helper"
-end
+require "assets_precompile_enforcer/sprockets/helpers/rails_helper"

--- a/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
+++ b/lib/assets_precompile_enforcer/sprockets/helpers/rails_helper.rb
@@ -27,7 +27,13 @@ module Sprockets
       end
 
       def enforce_precompile?
-        Rails.application.config.assets.enforce_precompile
+        enforce_precompile = Rails.application.config.assets.enforce_precompile
+
+        if enforce_precompile.is_a? Proc
+          enforce_precompile.call
+        else
+          enforce_precompile
+        end
       end
 
       def asset_list

--- a/lib/assets_precompile_enforcer/version.rb
+++ b/lib/assets_precompile_enforcer/version.rb
@@ -1,3 +1,3 @@
 module AssetsPrecompileEnforcer
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
The existing test prevents this gem from running if Konacha is loaded, even if Konacha isn't running. Factor out this check so that consumers can specify other, more specific checks.
